### PR TITLE
More flexibility on checking auth responses

### DIFF
--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -455,10 +455,7 @@ module.exports = class OAuth2Client extends EventEmitter {
       statusText,
     });
 
-    const shouldRefreshToken = await this.onShouldRefreshToken({
-      status,
-      headers,
-    });
+    const shouldRefreshToken = await this.onShouldRefreshToken(response);
     if (shouldRefreshToken) {
       if (didRefreshToken) {
         throw new OAuth2Error('Token refresh failed');


### PR DESCRIPTION
If we pass the full response to the function, overrides have more flexibility on checking if tokens need to be refreshed, because API builders really like to deviate from the specifications. 