### PR TITLE
fix: body not passed in request

### DIFF
--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -273,6 +273,7 @@ module.exports = class OAuth2Client extends EventEmitter {
     opts.method = method;
     opts.headers = headers;
     opts.headers = await this.onRequestHeaders({ headers: opts.headers });
+    opts.body = body
 
     let urlAppend = '';
     query = await this.onRequestQuery({

--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -273,7 +273,6 @@ module.exports = class OAuth2Client extends EventEmitter {
     opts.method = method;
     opts.headers = headers;
     opts.headers = await this.onRequestHeaders({ headers: opts.headers });
-    opts.body = body
 
     let urlAppend = '';
     query = await this.onRequestQuery({
@@ -292,6 +291,8 @@ module.exports = class OAuth2Client extends EventEmitter {
 
       opts.headers['Content-Type'] = opts.headers['Content-Type'] || 'application/json';
       opts.body = JSON.stringify(json);
+    } else if (body) {
+      opts.body = body
     }
 
     const url = `${this._apiUrl}${path}${urlAppend}`;


### PR DESCRIPTION
```javascript
async sync() {
    const params = new URLSearchParams();
    params.append('token', this._token.access_token);
    params.append('sync_token', '*');
    params.append('resource_types', '["user"]');

    // node fetch will set content type to application/x-www-form-urlencoded
    // because of url search params 

    // body is never passed here
    console.log(
      await this.post({
        path: '/sync/v8/sync',
        body: params,
      })
    );

    // this works fine with locally installed node-fetch package
    return fetch('https://api.todoist.com/sync/v8/sync', {
      method: 'POST',
      body: params,
    })
      .then((res) => res.json())
      .then((json) => console.log(json));
  }
```