### PR TITLE
Added support for authorizationUrl with existing query params

### DIFF
--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -587,7 +587,11 @@ module.exports = class OAuth2Client extends EventEmitter {
       redirect_uri: this._redirectUrl,
     };
 
-    return `${this._authorizationUrl}?${querystring.stringify(query)}`;
+    if (-1 === this._authorizationUrl.indexOf('?')) {
+      return `${this._authorizationUrl}?${querystring.stringify(query)}`;
+    }
+
+    return `${this._authorizationUrl}&${querystring.stringify(query)}`;
   }
 
   // https://tools.ietf.org/html/rfc6749#appendix-A.4


### PR DESCRIPTION
This PR adds support for an `authorizationUrl` that contains query parameters of it own. 

`OAuth2Client::onHandleAuthorizationURL()` currently assumes that the provided URL is a 'simple' URL, and appends the query string by using a `?`. This PR changes this behavior, and makes it switch to `&` if it finds a pre-existing `?` in the URL.

**Before (example)**
```
https://auth.provider.tld/auth?access_type=offline&prompt=consent?response_type=code&[...]
                                  this is where things go south ☝️
```

**After (example)**
`https://auth.provider.tld/auth?access_type=offline&prompt=consent&response_type=code&[...]`