### PR TITLE
Feature/fix delete sessions

### DIFF
--- a/lib/OAuth2App.js
+++ b/lib/OAuth2App.js
@@ -329,14 +329,21 @@ module.exports = class OAuth2App extends Homey.App {
     sessionId,
     configId = 'default',
   }) {
-    const foundSession = false;
+    let foundSession = false;
 
+    // Loop drivers from manifest
+    // Homey.drivers.getDrivers() may return an incomplete array
+    // when the Driver hasn't been initialized yet.
     const { drivers } = this.homey.manifest;
-    for (const driverId of drivers) {
-      let driver;
+    for (const driver of Object.values(drivers)) {
+      const driverId = driver.id;
+      let driverInstance;
+
+      // Get driver instance when it's ready
+      // eslint-disable-next-line no-constant-condition
       while (true) {
         try {
-          driver = this.homey.drivers.getDriver(driverId);
+          driverInstance = this.homey.drivers.getDriver(driverId);
           break;
         } catch (err) {
           await OAuth2Util.wait(500);
@@ -344,29 +351,23 @@ module.exports = class OAuth2App extends Homey.App {
         }
       }
 
-      console.log('driver', driver);
-      await driver.ready();
-      const devices = driver.getDevices();
-      console.log('devices', devices);
+      // Get the driver's devices and find a device
+      // that uses this OAuth2Session.
+      await driverInstance.ready();
+      const devices = driverInstance.getDevices();
+      for (const device of Object.values(devices)) {
+        const {
+          OAuth2ConfigId,
+          OAuth2SessionId,
+        } = device.getStore();
+
+        if (OAuth2SessionId === sessionId && OAuth2ConfigId === configId) {
+          foundSession = true;
+        }
+      }
     }
 
-    // const drivers = this.homey.drivers.getDrivers();
-    // for (const driver of Object.values(drivers)) {
-    //   const devices = driver.getDevices();
-    //   // eslint-disable-next-line no-loop-func
-    //   devices.forEach(device => {
-    //     const {
-    //       OAuth2ConfigId,
-    //       OAuth2SessionId,
-    //     } = device.getStore();
-
-    //     if (OAuth2SessionId === sessionId && OAuth2ConfigId === configId) {
-    //       foundSession = true;
-    //     }
-    //   });
-    // }
-
-    return !foundSession;
+    return foundSession === false;
   }
 
 };

--- a/lib/OAuth2App.js
+++ b/lib/OAuth2App.js
@@ -14,12 +14,8 @@ const sClients = Symbol('clients');
 
 module.exports = class OAuth2App extends Homey.App {
 
-  static API_URL = null;
-  static TOKEN_URL = null;
-  static AUTHORIZATION_URL = null;
-  static REDIRECT_URL = 'https://callback.athom.com/oauth2/callback';
-  static SCOPES = [];
   static OAUTH2_DEBUG = false;
+  static OAUTH2_CLIENT = OAuth2Client;
 
   async onInit() {
     this[sDebug] = false;
@@ -31,6 +27,7 @@ module.exports = class OAuth2App extends Homey.App {
 
   async onOAuth2Init() {
     // Overload Me
+    // Default behavior is to use defaults
 
     if (this.constructor.OAUTH2_DEBUG) {
       this.enableOAuth2Debug();
@@ -57,16 +54,16 @@ module.exports = class OAuth2App extends Homey.App {
     configId = 'default',
     token = OAuth2Token,
     grantType = 'authorization_code',
-    client = OAuth2Client,
+    client = this.constructor.OAUTH2_CLIENT,
     clientId = Homey.env.CLIENT_ID,
     clientSecret = Homey.env.CLIENT_SECRET,
-    apiUrl = client.constructor.API_URL,
-    tokenUrl = client.constructor.TOKEN_URL,
-    authorizationUrl = client.constructor.AUTHORIZATION_URL,
-    redirectUrl = client.constructor.REDIRECT_URL,
-    scopes = client.constructor.SCOPES,
+    apiUrl = client.API_URL,
+    tokenUrl = client.TOKEN_URL,
+    authorizationUrl = client.AUTHORIZATION_URL,
+    redirectUrl = client.REDIRECT_URL,
+    scopes = client.SCOPES,
     allowMultiSession = false,
-  }) {
+  } = {}) {
     if (typeof configId !== 'string') {
       throw new OAuth2Error('Invalid Config ID');
     }

--- a/lib/OAuth2App.js
+++ b/lib/OAuth2App.js
@@ -4,6 +4,7 @@ const Homey = require('homey');
 const OAuth2Error = require('./OAuth2Error');
 const OAuth2Token = require('./OAuth2Token');
 const OAuth2Client = require('./OAuth2Client');
+const OAuth2Util = require('./OAuth2Util');
 
 const SETTINGS_KEY = 'OAuth2Sessions';
 
@@ -13,16 +14,29 @@ const sClients = Symbol('clients');
 
 module.exports = class OAuth2App extends Homey.App {
 
-  onInit() {
+  static API_URL = null;
+  static TOKEN_URL = null;
+  static AUTHORIZATION_URL = null;
+  static REDIRECT_URL = 'https://callback.athom.com/oauth2/callback';
+  static SCOPES = [];
+  static OAUTH2_DEBUG = false;
+
+  async onInit() {
     this[sDebug] = false;
     this[sConfigs] = {};
     this[sClients] = {};
 
-    return this.onOAuth2Init();
+    await this.onOAuth2Init();
   }
 
-  onOAuth2Init() {
-    // Extend me
+  async onOAuth2Init() {
+    // Overload Me
+
+    if (this.constructor.OAUTH2_DEBUG) {
+      this.enableOAuth2Debug();
+    }
+
+    this.setOAuth2Config();
   }
 
   enableOAuth2Debug() {
@@ -46,11 +60,11 @@ module.exports = class OAuth2App extends Homey.App {
     client = OAuth2Client,
     clientId = Homey.env.CLIENT_ID,
     clientSecret = Homey.env.CLIENT_SECRET,
-    apiUrl,
-    tokenUrl,
-    authorizationUrl,
-    redirectUrl = 'https://callback.athom.com/oauth2/callback',
-    scopes = [],
+    apiUrl = client.constructor.API_URL,
+    tokenUrl = client.constructor.TOKEN_URL,
+    authorizationUrl = client.constructor.AUTHORIZATION_URL,
+    redirectUrl = client.constructor.REDIRECT_URL,
+    scopes = client.constructor.SCOPES,
     allowMultiSession = false,
   }) {
     if (typeof configId !== 'string') {
@@ -300,8 +314,8 @@ module.exports = class OAuth2App extends Homey.App {
     sessionId,
     configId = 'default',
   }) {
-    process.nextTick(() => {
-      const shouldDeleteSession = this.onShouldDeleteSession({ sessionId });
+    Promise.resolve().then(async () => {
+      const shouldDeleteSession = await this.onShouldDeleteSession({ sessionId });
       if (shouldDeleteSession) {
         this.log(`Deleting session ${configId} ${sessionId}...`);
         this.deleteOAuth2Client({
@@ -309,30 +323,51 @@ module.exports = class OAuth2App extends Homey.App {
           configId,
         });
       }
+    }).catch(err => {
+      this.homey.error('Error deleting session', err);
     });
   }
 
-  onShouldDeleteSession({
+  async onShouldDeleteSession({
     sessionId,
     configId = 'default',
   }) {
-    let foundSession = false;
+    const foundSession = false;
 
-    const drivers = this.homey.drivers.getDrivers();
-    for (const driver of Object.values(drivers)) {
-      const devices = driver.getDevices();
-      // eslint-disable-next-line no-loop-func
-      devices.forEach(device => {
-        const {
-          OAuth2ConfigId,
-          OAuth2SessionId,
-        } = device.getStore();
-
-        if (OAuth2SessionId === sessionId && OAuth2ConfigId === configId) {
-          foundSession = true;
+    const { drivers } = this.homey.manifest;
+    for (const driverId of drivers) {
+      let driver;
+      while (true) {
+        try {
+          driver = this.homey.drivers.getDriver(driverId);
+          break;
+        } catch (err) {
+          await OAuth2Util.wait(500);
+          continue;
         }
-      });
+      }
+
+      console.log('driver', driver);
+      await driver.ready();
+      const devices = driver.getDevices();
+      console.log('devices', devices);
     }
+
+    // const drivers = this.homey.drivers.getDrivers();
+    // for (const driver of Object.values(drivers)) {
+    //   const devices = driver.getDevices();
+    //   // eslint-disable-next-line no-loop-func
+    //   devices.forEach(device => {
+    //     const {
+    //       OAuth2ConfigId,
+    //       OAuth2SessionId,
+    //     } = device.getStore();
+
+    //     if (OAuth2SessionId === sessionId && OAuth2ConfigId === configId) {
+    //       foundSession = true;
+    //     }
+    //   });
+    // }
 
     return !foundSession;
   }

--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -16,6 +16,12 @@ const OAuth2Util = require('./OAuth2Util');
  */
 module.exports = class OAuth2Client extends EventEmitter {
 
+  static API_URL = null;
+  static TOKEN_URL = null;
+  static AUTHORIZATION_URL = null;
+  static REDIRECT_URL = 'https://callback.athom.com/oauth2/callback';
+  static SCOPES = [];
+
   constructor({
     homey,
     token,
@@ -292,7 +298,7 @@ module.exports = class OAuth2Client extends EventEmitter {
       opts.headers['Content-Type'] = opts.headers['Content-Type'] || 'application/json';
       opts.body = JSON.stringify(json);
     } else if (body) {
-      opts.body = body
+      opts.body = body;
     }
 
     const url = `${this._apiUrl}${path}${urlAppend}`;

--- a/lib/OAuth2Util.js
+++ b/lib/OAuth2Util.js
@@ -11,4 +11,10 @@ module.exports = class OAuth2Util {
     });
   }
 
+  static async wait(delay = 1000) {
+    await new Promise(resolve => {
+      setTimeout(() => resolve(), delay);
+    });
+  }
+
 };


### PR DESCRIPTION
This PR fixes a bug where OAuth2Sessions would be deleted when the Driver instance wasn't returned when calling `Homey.drivers.getDrivers()`.

It also adds support to specify all OAuth2 properties (api url etc.) on Homey.App and OAuth2Client as statics.