### PR TITLE
Ensure clientId is send as client_id in password grant

### DIFF
--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -572,7 +572,7 @@ class OAuth2Client extends EventEmitter {
     body.append('scope', this._scopes.join(' '));
 
     if (this._clientId) {
-      body.append('client_secret', this._clientId);
+      body.append('client_id', this._clientId);
     }
 
     if (this._clientSecret) {


### PR DESCRIPTION
When trying to login via credentials, client_id is never sent as it is added to the incorrect parameter. 