### PR TITLE
Fixed a bug where the refresh token got lost whenever the server was rate limited (429 response)

### DIFF
--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -617,7 +617,7 @@ class OAuth2Client extends EventEmitter {
       body,
       method: 'POST',
     });
-    if (!response.ok) {
+    if (response.status === 401) {
       this._token = null;
       this.emit('expired');
       this.save();


### PR DESCRIPTION
Prior to this fix the refresh token was always lost around once every month.
After the fix it has been stable for 3 months without any disconnects.

The problem with the old code has been observed for both rate limited responses (429) and server errors (5xx)

See [Slack](https://athomcommunity.slack.com/archives/C04SUGZ9E/p1669000839103719) for more information