### PR TITLE
OAuth2Client using absolute path URL

### DIFF
--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -474,7 +474,10 @@ class OAuth2Client extends EventEmitter {
       opts.body = body;
     }
 
-    const url = `${this._apiUrl}${path}${urlAppend}`;
+    let url = `${this._apiUrl}${path}${urlAppend}`;
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      url = `${path}${urlAppend}`;
+    }
 
     return {
       url,


### PR DESCRIPTION
OAuth2Client.onBuildRequest:
Added check on "path" parameter. If absolute URL is orovided, the url is uses instead of this._apiUrl+path.