### PR TITLE
Improved usability with single OAuth2 session

### DIFF
--- a/lib/OAuth2App.js
+++ b/lib/OAuth2App.js
@@ -169,7 +169,6 @@ class OAuth2App extends Homey.App {
     this[sClients][configId] = {};
   }
 
-
   /*
    * OAuth2 Config Management
    * @param {object} args
@@ -207,7 +206,7 @@ class OAuth2App extends Homey.App {
     return this[sConfigs][configId];
   }
 
-  /*
+  /**
    * OAuth2 Client Management
    * @param {object} args
    * @param {string} args.sessionId
@@ -223,6 +222,21 @@ class OAuth2App extends Homey.App {
   }
 
   /**
+   * @returns {Promise<boolean>}
+   */
+  async hasOAuth2Devices({
+    sessionId = '',
+    configId = 'default',
+  } = {}) {
+    const devices = await this.getOAuth2Devices({
+      sessionId,
+      configId,
+    });
+
+    return devices.length > 0;
+  }
+
+  /**
    * @param {object} args
    * @param {string} args.sessionId
    * @param {string} args.configId
@@ -235,6 +249,15 @@ class OAuth2App extends Homey.App {
     if (!hasClient) {
       throw new OAuth2Error('Invalid OAuth2 Client');
     }
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  hasSingleOAuth2Session() {
+    const sessions = this.getSavedOAuth2Sessions();
+
+    return Object.keys(sessions).length === 1;
   }
 
   /**
@@ -385,18 +408,28 @@ class OAuth2App extends Homey.App {
    * @returns {OAuth2Client}
    */
   getFirstSavedOAuth2Client() {
+    const sessionId = this.getFirstOAuth2SessionId();
     const sessions = this.getSavedOAuth2Sessions();
-    if (Object.keys(sessions).length < 1) {
-      throw new OAuth2Error('No OAuth2 Client Found');
-    }
-
-    const [sessionId] = Object.keys(sessions);
     const { configId } = sessions[sessionId];
 
     return this.getOAuth2Client({
       configId,
       sessionId,
     });
+  }
+
+  /**
+   * @returns {string}
+   */
+  getFirstOAuth2SessionId() {
+    const sessions = this.getSavedOAuth2Sessions();
+    if (Object.keys(sessions).length < 1) {
+      throw new OAuth2Error('No OAuth2 Client Found');
+    }
+
+    const [sessionId] = Object.keys(sessions);
+
+    return sessionId;
   }
 
   /**
@@ -435,12 +468,7 @@ class OAuth2App extends Homey.App {
     sessionId,
     configId = 'default',
   }) {
-    const devices = await this.getOAuth2Devices({
-      sessionId,
-      configId,
-    });
-
-    return devices.length === 0;
+    return !this.hasOAuth2Devices({ configId, sessionId });
   }
 
   /**
@@ -450,10 +478,16 @@ class OAuth2App extends Homey.App {
    * @returns {Promise<array>}
    */
   async getOAuth2Devices({
-    sessionId,
+    sessionId = '',
     configId = 'default',
-  }) {
+  } = {}) {
     let result = [];
+
+    if (sessionId.length < 1) {
+      if (!this.hasSingleOAuth2Session()) return result;
+
+      sessionId = this.getFirstOAuth2SessionId();
+    }
 
     // Loop drivers from manifest
     // Homey.drivers.getDrivers() may return an incomplete array
@@ -469,7 +503,6 @@ class OAuth2App extends Homey.App {
           break;
         } catch (err) {
           await OAuth2Util.wait(500);
-          continue;
         }
       }
 
@@ -482,8 +515,7 @@ class OAuth2App extends Homey.App {
           OAuth2SessionId,
         } = device.getStore();
 
-        if (OAuth2SessionId === sessionId && OAuth2ConfigId === configId) return true;
-        return false;
+        return OAuth2SessionId === sessionId && OAuth2ConfigId === configId;
       });
       result = [...devices, ...result];
     }


### PR DESCRIPTION
I use this library a lot for my apps. All just use 1 single OAuth2 client and every time I want to check if there are any OAuth2 devices available (for timer etc), I need to use the boiler template below because everywhere the `sessionId` is needed:

```js
class App extends OAuth2App {
  ...

  // Return client devices
  async getClientDevices() {
    const sessions = this.getSavedOAuth2Sessions();

    if (blank(sessions)) {
      return [];
    }

    const sessionId = Object.keys(sessions)[0];

    return this.getOAuth2Devices({ sessionId });
  }

  ...
}
```

In this PR, the now required `sessionId` parameter for the `getOAuth2Devices()` function is optional, and will grap the first session key by default **if available**.

I also added a few functions which are shortcuts to already existing functionalities, but make it a bit more pleasant to work with.

There should not be any breaking changes as far as I can see.

Let me know what you think!

-- Edwin