### PR TITLE
fix: consistent oauth2 functions

### DIFF
--- a/lib/OAuth2App.js
+++ b/lib/OAuth2App.js
@@ -57,8 +57,26 @@ class OAuth2App extends Homey.App {
   /**
    * @returns {Promise<void>}
    */
+  async onUninit() {
+    await this.onOAuth2Uninit();
+  }
+
+  /**
+   * @description
+   * > This method can be extended
+   * @returns {Promise<void>}
+   */
   async onOAuth2Init() {
-    // Overload Me
+    // Extend me
+  }
+
+  /**
+   * @description
+   * > This method can be extended
+   * @returns {Promise<void>}
+   */
+  async onOAuth2Uninit() {
+    // Extend me
   }
 
   /**

--- a/lib/OAuth2Driver.js
+++ b/lib/OAuth2Driver.js
@@ -25,11 +25,27 @@ class OAuth2Driver extends Homey.Driver {
   }
 
   /**
+   * @returns {Promise<void>}
+   */
+  async onUninit() {
+    await this.onOAuth2Uninit();
+  }
+
+  /**
    * @description
    * > This method can be extended
    * @returns {Promise<void>}
    */
   async onOAuth2Init() {
+    // Extend me
+  }
+
+  /**
+   * @description
+   * > This method can be extended
+   * @returns {Promise<void>}
+   */
+  async onOAuth2Uninit() {
     // Extend me
   }
 


### PR DESCRIPTION
Hi there,

Every time I'm working on an app that uses this package, I am confused why I did not use the `onOAuth2Uninit` functions in the App and Driver classes. Answer is simple; they don't exist ... yet. 😉

While the `OAuth2Device` class has overwrites for all device events (`onAdded`, `onDeleted` etc.), I was missing the `onOAuth2Uninit` function in the `OAuth2Driver` and `OAuth2App` classes.

This PR adds those functions for consistency, and will eventually cause less confusion when working with this package.

No breaking changes.

-- Edwin

