### PR TITLE
Fix device repair when using login credentials

### DIFF
--- a/lib/OAuth2Driver.js
+++ b/lib/OAuth2Driver.js
@@ -289,6 +289,21 @@ class OAuth2Driver extends Homey.Driver {
       });
     }
 
+    const onSuccess = async () => {
+      await device.onOAuth2Uninit();
+      await device.setStoreValue('OAuth2SessionId', OAuth2SessionId);
+      await device.setStoreValue('OAuth2ConfigId', OAuth2ConfigId);
+      await client.save();
+      device.oAuth2Client = client;
+      await device.onOAuth2Init();
+    };
+
+    const onLogin = async ({ username, password }) => {
+      await client.getTokenByCredentials({ username, password });
+      await onSuccess();
+      return true;
+    };
+
     const onShowViewLoginOAuth2 = async () => {
       try {
         const oAuth2AuthorizationUrl = client.getAuthorizationUrl();
@@ -300,13 +315,7 @@ class OAuth2Driver extends Homey.Driver {
           .on('code', code => {
             client.getTokenByCode({ code })
               .then(async () => {
-                await device.onOAuth2Uninit();
-                await device.setStoreValue('OAuth2SessionId', OAuth2SessionId);
-                await device.setStoreValue('OAuth2ConfigId', OAuth2ConfigId);
-                await client.save();
-                device.oAuth2Client = client;
-                await device.onOAuth2Init();
-
+                await onSuccess();
                 socket.emit('authorized').catch(this.error);
               })
               .catch(err => {
@@ -330,6 +339,7 @@ class OAuth2Driver extends Homey.Driver {
 
     socket
       .setHandler('showView', onShowView)
+      .setHandler('login', onLogin)
       .setHandler('disconnect', onDisconnect);
   }
 


### PR DESCRIPTION
When using login credentials, attempting to repair a device would lead to "Invalid credentials" error. This fixes the issue, however I am not sure if this is the "right" fix.

Happy for this to be discarded in favour of a better fix.