### PR TITLE
Ensure driver uses temp client correctly with multi-session

### DIFF
--- a/lib/OAuth2Driver.js
+++ b/lib/OAuth2Driver.js
@@ -218,6 +218,11 @@ class OAuth2Driver extends Homey.Driver {
           configId: OAuth2ConfigId,
           sessionId: OAuth2SessionId,
         });
+      } else {
+        client = this.homey.app.createOAuth2Client({
+          sessionId: OAuth2Util.getRandomId(),
+          configId: OAuth2ConfigId,
+        });
       }
     };
 


### PR DESCRIPTION
This change was required to enable login to a new client session when multi-session was enabled. Previously, there was an odd scenario were the last client session that was created was being destroyed due to the `client.destroy()` in the `onLogin` implementation in `onPair` instead of using the temporary session.