### PR TITLE
fix(client): emit expiry event on refresh token error

### DIFF
--- a/lib/OAuth2Client.js
+++ b/lib/OAuth2Client.js
@@ -631,6 +631,12 @@ class OAuth2Client extends EventEmitter {
       method: 'POST',
     });
     if (!response.ok) {
+      if ([400, 401, 403].includes(response.status)) {
+        // we likely received invalid_grant, which means the refresh token has expired and
+        // needs re-authentication
+        this.emit('expired');
+      }
+
       return this.onHandleRefreshTokenError({ response });
     }
 


### PR DESCRIPTION
When an attempt to refresh token receives a 400, 401 or 403 we can assume that the refresh token is no longer valid and requires re-authentication. This change emits an "expired" event when this happens.